### PR TITLE
Add custom port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Setup
+## Environment variables
+- `PORT`: custom port to listen on. Defaults to `3000`.

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 
 const app = express();
 
-const PORT = 3000;
+const PORT = process.env.PORT ?? 3000;
 
 app.get('/', (req, res) => res.send('🚀'));
 


### PR DESCRIPTION
Allow to specify a custom port through the `PORT` environment variable.